### PR TITLE
Add bootloader and app header skipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+*.elf

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import traceback
 import os


### PR DESCRIPTION
This reads the segments and ignores the bootloader and app header segments as they should not be touched.
This pr makes it easier to have a single elf file with bootloader included instead of a bootloader version and one without bootloader.

Same functionality as in https://github.com/usedbytes/serial-flash/pull/4